### PR TITLE
add: compatibility to picoCMS 2.1 and php 7.4.

### DIFF
--- a/PicoComments.php
+++ b/PicoComments.php
@@ -9,7 +9,7 @@
 class PicoComments extends AbstractPicoPlugin
 {
     protected $enabled = true;                      // whether this plugin is enabled by default sitewide
-    protected $content_path = __DIR__ . '/content'; // content storage path. by default this is inside the plugin directory itself so that everything is self-contained
+    protected $content_path = __DIR__ . '/../blog-comments'; // content storage path
     protected $headers;                             // current page headers ("meta", "frontmatter", NOT HTML headers)
     protected $id;                                  // current page URL ("id")
     protected $num_comments = 0;                    // number of comments on this page
@@ -105,7 +105,6 @@ class PicoComments extends AbstractPicoPlugin
                 $comment = [
                     'content' => $content
                 ];
-                
                 foreach($meta as $key => $value) {
                     if (strlen($meta[$key]) > 0) {
                         $comment[$key] = $value;
@@ -126,6 +125,8 @@ class PicoComments extends AbstractPicoPlugin
         
         // this recursive function builds and sorts the child-pointer tree
         function insert_replies(&$array, &$comments) {
+            if (!is_array($array) || !is_object($array))
+                return;
             foreach($array as &$comment) {
                 // if this comment has children,
                 if (isset($comments[$comment['guid']])) {
@@ -150,8 +151,9 @@ class PicoComments extends AbstractPicoPlugin
         // remove the extra array wrapper around the top level
         $comments = $comments[""];
         // sort the top level
+        if (!is_array($comments) && !is_object($comments))
+           return;
         usort($comments, function($a, $b) { return $b['date'] <=> $a['date']; });
-
         return $comments;
     }
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,16 @@ All other comment properties (guid, date of posting, ip address, pending review)
 
 Comment content and author names are sanitized before being saved. Comment reply GUIDs are validated before the comment is saved, and if the comment pointed to by the reply GUID does not exist, the comment will not be accepted.
 
-Comments are stored as files in the plugin's ```content``` directory in a manner very similar to Pico's own page structure. The structure of a comment file is as follows:
+Comments are stored as files in a a folder named ```blog-comments``` in a manner very similar to Pico's own page structure. 
+If the folder creation fails, please create the folder yourself next to the ``ìndex.php`` and give it the correct access rights. Named 0755 for the file mode and the WWW user as owner. So under Linux for example via:
+```
+cd picocms
+cd picocms
+mkdir blog-comments
+chmod 0775 blog-comments && chown www-data:www-data blog-comments
+```
+
+The structure of a comment file is as follows:
 ```
 ---
 guid


### PR DESCRIPTION
PicoCMS 2.1 no longer allows empty or filled directories to reside in the plugins folder, but not containing plugins. Therefore the folder was moved to the root level.
Also, exceptions appeared in php 7.4.2 because empty arrays are no longer allowed to be used just like that. E.g. in usort or foreach. 